### PR TITLE
Address Ganon ER logic review

### DIFF
--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -4,7 +4,9 @@
         "dungeon": "Ganons Castle",
         "exits": {
             "Castle Grounds": "True",
-            "Ganons Castle Main": "here(is_adult or (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang)) or (has_explosives and (Sticks or ((Nuts or Boomerang) and Slingshot))))"
+            "Ganons Castle Main": "here(is_adult or
+                (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang)) or
+                (has_explosives and (Sticks or ((Nuts or Boomerang) and Slingshot))))"
         }
     },
     {
@@ -46,9 +48,9 @@
             "Forest Trial Clear": "can_use(Light_Arrows) and can_play(Song_of_Time)"
         },
         "locations": {
-            "Ganons Castle MQ Forest Trial Eye Switch Chest": "can_use(Bow) or (can_use(Slingshot) and Kokiri_Sword)",
+            "Ganons Castle MQ Forest Trial Eye Switch Chest": "here(is_adult or Kokiri_Sword) and (can_use(Bow) or can_use(Slingshot))",
             "Ganons Castle MQ Forest Trial Frozen Eye Switch Chest": "has_fire_source and (is_adult or Kokiri_Sword)",
-            "Ganons Castle MQ Forest Trial Freestanding Key": "can_use(Progressive_Hookshot) or (can_use(Boomerang) and Kokiri_Sword)"
+            "Ganons Castle MQ Forest Trial Freestanding Key": "here(is_adult or Kokiri_Sword) and (can_use(Hookshot) or can_use(Boomerang))"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1940,7 +1940,7 @@
         "dungeon": "Ganons Castle",
         "locations": {
             "Ganons Tower Boss Key Chest": "is_adult or Kokiri_Sword",
-            "Ganondorf Hint": "Boss_Key_Ganons_Castle",
+            "Ganondorf Hint": "(is_adult or Kokiri_Sword) and Boss_Key_Ganons_Castle",
             "Ganon": "Boss_Key_Ganons_Castle and can_use(Light_Arrows)"
         }
     },


### PR DESCRIPTION
Addresses https://github.com/TestRunnerSRL/OoT-Randomizer/pull/1546#issuecomment-1114574428. Also adds some line breaks to the access from MQ `Ganons Castle Lobby` to `Ganons Castle Main`.