### PR TITLE
Logic for coming out of Ganon's castle exit before the rainbow bridge is spawned

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -100,7 +100,7 @@ entrance_shuffle_table = [
     ('Dungeon',         ('Gerudo Fortress -> Gerudo Training Ground Lobby',                 { 'index': 0x0008 }),
                         ('Gerudo Training Ground Lobby -> Gerudo Fortress',                 { 'index': 0x03A8 })),
     ('DungeonSpecial',  ('Ganons Castle Grounds -> Ganons Castle Lobby',                    { 'index': 0x0467 }),
-                        ('Ganons Castle Lobby -> Castle Grounds',                           { 'index': 0x023D })),
+                        ('Ganons Castle Lobby -> Castle Grounds From Ganons Castle',        { 'index': 0x023D })),
 
     ('Interior',        ('Kokiri Forest -> KF Midos House',                                 { 'index': 0x0433 }),
                         ('KF Midos House -> Kokiri Forest',                                 { 'index': 0x0443 })),

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -3,7 +3,7 @@
         "region_name": "Ganons Castle Lobby",
         "dungeon": "Ganons Castle",
         "exits": {
-            "Castle Grounds": "True",
+            "Castle Grounds From Ganons Castle": "True",
             "Ganons Castle Main": "here(is_adult or
                 (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang)) or
                 (has_explosives and (Sticks or ((Nuts or Boomerang) and Slingshot))))"

--- a/data/World/Ganons Castle.json
+++ b/data/World/Ganons Castle.json
@@ -3,7 +3,7 @@
         "region_name": "Ganons Castle Lobby",
         "dungeon": "Ganons Castle",
         "exits": {
-            "Castle Grounds": "True",
+            "Castle Grounds From Ganons Castle": "True",
             "Ganons Castle Forest Trial": "True",
             "Ganons Castle Fire Trial": "True",
             "Ganons Castle Water Trial": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -851,6 +851,17 @@
         }
     },
     {
+        "region_name": "Castle Grounds From Ganons Castle",
+        "font_color": "Light Blue",
+        "scene": "Castle Grounds",
+        "hint": "outside Ganon's Castle",
+        "exits": {
+            # the rainbow bridge cutscene trigger doesn't extend to the castle entrance
+            "Ganons Castle Grounds": "is_adult and bridge == 'open'"
+            # no exit back into the castle because the entrance places Link in midair if the bridge isn't spawned
+        }
+    },
+    {
         "region_name": "Ganons Castle Grounds",
         "font_color": "Light Blue",
         "scene": "Castle Grounds",


### PR DESCRIPTION
@cjohnson57 answered yes to the question from https://github.com/TestRunnerSRL/OoT-Randomizer/pull/1546#issuecomment-1139050695 in #dev-public-talk. Since I don't know how to change the entrance position, this PR contains the logic fix.